### PR TITLE
Add no-function-overriding rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Below are the rules supplied by this plugin and the information on passing optio
 | no-unreachable-code            | Disallow unreachable code                                                                        |                                   |                                      |       |
 | no-user-defined-modifiers      | Disallow user-defined modifiers                                                                  |                                   |                                      |       |
 | no-void-returns                | Discourage use of void returns in functions prototypes                                           |                                   |                                      |       |
+| no-function-overriding         | Discourage function overriding                                                                   |                                   |                                      |       |
 
 An example `soliumrc.json` configuring and applying this plugin is:
 

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ module.exports = {
 		"no-tx-origin": require("./rules/no-tx-origin"),
 		"no-unreachable-code": require("./rules/no-unreachable-code"),
 		"no-user-defined-modifiers": require("./rules/no-user-defined-modifiers"),
-		"no-void-returns": require("./rules/no-void-returns")
+		"no-void-returns": require("./rules/no-void-returns"),
+		"no-function-overriding": require("./rules/no-function-overriding")
 	}
 };

--- a/rules/no-function-overriding.js
+++ b/rules/no-function-overriding.js
@@ -1,0 +1,105 @@
+/**
+ * @fileoverview Discourage function overriding
+ * @author Nicolas Feignon <nfeignon@gmail.com>
+ */
+
+'use strict';
+
+module.exports = {
+
+    meta: {
+
+        docs: {
+            recommended: true,
+            type: 'error',
+            description: 'Discourage function overriding'
+        },
+
+        schema: []
+
+    },
+
+    create: function (context) {
+
+        var contracts = {};
+
+        function inspectContractStatement(emitted) {
+            if (emitted.exit) { return; }
+            var node = emitted.node;
+
+            contracts[node.name] = {'functions': {}, 'parents': [], 'node': node}
+            for (let expr of node.body) {
+                if (expr.type !== 'FunctionDeclaration' || !expr.name) { continue; }
+
+                var signature = [];
+                if (expr.params) {
+                    for (let param of expr.params) {
+                        signature.push(param.literal.literal);
+                    }
+                }
+
+                contracts[node.name].functions[expr.name] = signature;
+            }
+
+            for (let parent of node.is) {
+                contracts[node.name].parents.push(parent.name);
+            }
+        }
+
+        function inspectProgram(emitted) {
+            if (!emitted.exit) { return; }
+
+            for (let name in contracts) {
+                let contract = contracts[name];
+                if (contract.parents.length === 0) { continue; }    // top-level contract, ignore
+
+                for (let func_name in contract.functions) {
+                    inspectHigherLevelContracts(name, func_name, name);
+                }
+            }
+        }
+
+        function inspectHigherLevelContracts(contract_name, func_name, origin) {
+            var contract = contracts[contract_name];
+            for (let parent of contract.parents) {
+                if (!Object.keys(contracts).includes(parent)) { continue; }
+
+                let sameName = Object.keys(contracts[parent].functions).includes(func_name);
+                let sameSignature = true;
+
+                if (sameName) {     // do we have functions with the same name
+                    let func_args = contracts[origin].functions[func_name];
+                    let parent_func_args = contracts[parent].functions[func_name];
+
+                    // Compare signatures of both functions
+                    if (func_args.length === parent_func_args.length) {
+                        for (let i = 0; i < func_args.length; i++) {
+                            if (func_args[i] !== parent_func_args[i]) {
+                                sameSignature = false;
+                                break;
+                            }
+                        }
+                    } else {
+                        sameSignature = false;
+                    }
+                }
+
+                if (sameName && sameSignature) {
+                    context.report({
+                        node: contracts[origin].node,
+                        message: "Function " + func_name + " redefined in contract " + origin
+                    });
+                }
+
+                inspectHigherLevelContracts(parent, func_name, origin);     // inspect parent to go up in the inheritance chain
+            }
+        }
+
+        return {
+            ContractStatement: inspectContractStatement,
+            Program: inspectProgram
+        };
+
+    }
+
+};

--- a/test/index.js
+++ b/test/index.js
@@ -23,7 +23,7 @@ describe("Check Plugin's exported object", () => {
 		meta.description.should.be.type("string");
 
 		rules.should.be.type("object");
-		rules.should.have.size(31);
+		rules.should.have.size(32);
 
 		for (let ruleName in rules) {
 			rules[ruleName].should.be.type("object");

--- a/test/no-function-overriding.js
+++ b/test/no-function-overriding.js
@@ -1,0 +1,173 @@
+/**
+ * @fileoverview Test for no-function-overriding rule
+ * @author Nicolas Feignon <nfeignon@gmail.com>
+ */
+
+'use strict';
+
+var Solium = require ('solium');
+
+var userConfig = {
+    rules: {
+        "security/no-function-overriding": "error"
+    }
+};
+
+describe ('[RULE] no-function-overriding: Acceptances', function () {
+
+    it ('should accept contracts that don\'t override their inherited functions', function (done) {
+        var code = [
+            `
+                contract A {
+                    function foo();
+                    function ();
+                }
+                contract B is A {
+                    function bar();
+                    function ();
+                }
+            `,
+            `
+                contract A {
+                    function foo();
+                }
+                contract B is A {
+                    function bar();
+                    function();
+                }
+                contract C {
+                    function foo();
+                }
+            `,
+            `
+                contract A {
+                    function foo();
+                }
+                contract B is A {
+                    function bar();
+                    function foo(uint);
+                }
+            `,
+            `
+                contract A {
+                    function foo();
+                }
+                contract B is A {
+                    function foo(uint, string);
+                }
+                contract C is B {
+                    function foo(uint);
+                }
+            `,
+            `
+                contract A {
+                    function foo() returns (string);
+                }
+                contract B is A {
+                    function foo(uint, string) payable public;
+                }
+                contract C is B {
+                    function foo(uint);
+                }
+            `
+        ];
+        var errors;
+
+        for (let expr of code) {
+            errors = Solium.lint (expr, userConfig);
+            errors.length.should.equal (0);
+        }
+
+        Solium.reset ();
+        done ();
+    });
+});
+
+describe ('[RULE] no-function-overriding: Rejections', function () {
+
+    it ('should reject contracts that override their inherited functions', function (done) {
+        var code = [
+            `
+                contract A {
+                    function foo();
+                }
+                contract B is A {
+                    function foo() { return; }
+                }
+            `,
+            `
+                contract A {
+                    function foo();
+                    function bar(uint, string);
+                    function();
+                }
+                contract B is A {
+                    function bar(uint, string);
+                }
+                contract C is B {
+                    function foo(uint);
+                }
+                contract D is C {
+                    function foo(uint);
+                }
+            `,
+            `
+                contract A {
+                    function foo() returns (string);
+                    function();
+                }
+                contract B is A {
+                }
+                contract C is B {
+                    function foo() returns (string);
+                }
+            `,
+            `
+                contract A {
+                    function bar(string s, uint u) public;
+                }
+                contract B is A {
+                    function bar(string s, uint u) public;
+                }
+            `,
+            `
+                contract A {
+                    function bar(string s, uint u) public;
+                }
+                contract B  {
+                }
+                contract C is A,B {
+                    function bar(string s, uint u) public;
+                }
+            `,
+            `
+                contract A {
+                    function bar(string s, uint u) public;
+                }
+                contract B  {
+                    function bar(string, uint) public;
+                }
+                contract C is A,B {
+                    function bar(string s, uint u) public;
+                }
+            `
+        ];
+        var errors;
+
+        errors = Solium.lint (code[0], userConfig);
+        errors.length.should.equal (1);
+        errors = Solium.lint (code[1], userConfig);
+        errors.length.should.equal (2);
+        errors = Solium.lint (code[2], userConfig);
+        errors.length.should.equal (1);
+        errors = Solium.lint (code[3], userConfig);
+        errors.length.should.equal (1);
+        errors = Solium.lint (code[4], userConfig);
+        errors.length.should.equal (1);
+        errors = Solium.lint (code[5], userConfig);
+        errors.length.should.equal (2);
+
+        Solium.reset ();
+        done ();
+    });
+});


### PR DESCRIPTION
In response to the [Augur bug bounty](https://augur.net/bounties/) : _Prohibit function overriding_

This works by first building a dictionary of all contracts and their parents in the _inspectContractStatement_.
Then it loops over the dict to find overriding functions. It detects an overriding function if there's a function with the same name and arguments up in the chain.

I haven't rebased this on the mainline as you have other PR to merge but I could of course do it.

Tell me what you think about my implementation :)