### PR TITLE
fix the no-send case where a CallExpression node has no property

### DIFF
--- a/rules/no-send.js
+++ b/rules/no-send.js
@@ -6,7 +6,9 @@
 'use strict';
 
 function isSend (calleeNode) {
-	return (calleeNode.property.type === 'Identifier' &&
+	return (
+		calleeNode.property &&
+		calleeNode.property.type === 'Identifier' &&
 		calleeNode.property.name === 'send'
 	);
 }
@@ -32,7 +34,7 @@ module.exports = {
 
 			var callee = emittedObject.node.callee;
 
-			if (isSend (callee.parent)) {
+			if (isSend (callee)) {
 				context.report ({
 					node: emittedObject.node,
 					message: '\'send\' is unsafe. Instead, consider using \'transfer\' or a pattern where the recipient withdraws the money.'

--- a/test/no-send.js
+++ b/test/no-send.js
@@ -20,15 +20,33 @@ describe ('[RULE] no-send: Rejections', function () {
 		// http://solidity.readthedocs.io/en/develop/security-considerations.html#re-entrancy
 		var code = "contract Fund {\
 			mapping(address => uint) shares; \
+			function other() {return 0;}\
 			function withdraw() {\
 				if (msg.sender.send(shares[msg.sender]))\
 					shares[msg.sender] = 0;\
+				other();\
 			}\
 		}",
 			errors = Solium.lint (code, userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
+
+		Solium.reset ();
+		done ();
+	});
+
+	it ('should work correctly for non-property functions, regardless of name', function (done) {
+		var code = "contract Fund {\
+			mapping(address => uint) shares; \
+			function send() {return 0;}\
+			function main() {\
+				send();\
+			}\
+		}",
+			errors = Solium.lint (code, userConfig);
+
+		errors.length.should.equal (0);
 
 		Solium.reset ();
 		done ();


### PR DESCRIPTION
@duaraghav8 resolves issue(s) from https://github.com/duaraghav8/solium-plugin-security/pull/5

* Passes `callee` instead of `callee.parent`
* Ensures that the `callee` node has a `property` before testing for it
* Added a test case to ensure the above works properly

Sorry again about the mix up, let me know that it works for you!