### PR TITLE
Add a no-interface option to no-inheritance and no-multiple-inheritance

### DIFF
--- a/rules/no-multiple-inheritance.js
+++ b/rules/no-multiple-inheritance.js
@@ -15,26 +15,70 @@ module.exports = {
             description: 'Discourage use of multiple inheritance'
         },
 
-        schema: []
+        schema: [{
+            type: 'object',
+            properties: {
+                'no-interface': { type: 'boolean' }
+            },
+            additionalProperties: false
+        }]
 
     },
 
     create: function (context) {
 
+        var interfaces = [];
+        var contracts = {};
+
+        var noInterface = context.options && context.options[0]['no-interface'];
+
+        function inspectInterfaceStatement(emitted) {
+            if (emitted.exit || noInterface) { return; }
+
+            interfaces.push(emitted.node.name);
+        }
+
         function inspectContractStatement(emitted) {
             if (emitted.exit) { return; }
             var node = emitted.node;
 
-            if (node.is.length > 1) {
+            if (noInterface && (node.is.length > 1)) {
                 context.report({
                     node: node,
                     message: 'Avoid using multiple inheritance for Contract ' + node.name
                 });
+                return;
+            }
+
+            contracts[node.name] = {'parents': [], 'node': node}
+            for (let parent of node.is) {
+                contracts[node.name].parents.push(parent.name);
+            }
+
+        }
+
+        function inspectProgram(emitted) {
+            if (!emitted.exit || noInterface) { return; }
+
+            for (let name in contracts) {
+                let contract = contracts[name];
+
+                for (let parent of contract.parents) {
+                    if (!interfaces.includes(parent) && contract.parents.length > 1) {
+                        context.report({
+                            node: contract.node,
+                            message: 'Avoid using multiple inheritance for Contract ' + name
+                        });
+                        break;
+                    }
+                }
             }
         }
 
         return {
-            ContractStatement: inspectContractStatement
+            InterfaceStatement: inspectInterfaceStatement,
+            ContractStatement: inspectContractStatement,
+            Program: inspectProgram
         };
 
     }

--- a/test/no-inheritance.js
+++ b/test/no-inheritance.js
@@ -13,14 +13,36 @@ var userConfig = {
     }
 };
 
+var userConfigNoInterface = {
+    rules: {
+        "security/no-inheritance": ["error", { "no-interface": true }]
+    }
+};
+
 describe ('[RULE] no-inheritance: Acceptances', function () {
 
-    it ('should accept programs that don\'t use inheritance', function (done) {
+    it ('should accept programs that don\'t use inheritance and don\'t allow interfaces', function (done) {
         var code = 'contract Foo {}';
         var errors;
 
-        errors = Solium.lint (code, userConfig);
+        errors = Solium.lint (code, userConfigNoInterface);
         errors.length.should.equal (0);
+
+        Solium.reset ();
+        done ();
+    });
+
+    it ('should accept programs that use inheritance with interfaces', function (done) {
+        var code = [
+            'interface Foo {}\ncontract Bar is Foo {}',
+            'interface Foo {}\ninterface Bar {}\ncontract FooBar is Foo,Bar {}'
+        ];
+        var errors;
+
+        for (let expr of code) {
+            errors = Solium.lint (expr, userConfig);
+            errors.length.should.equal (0);
+        }
 
         Solium.reset ();
         done ();
@@ -29,12 +51,63 @@ describe ('[RULE] no-inheritance: Acceptances', function () {
 
 describe ('[RULE] no-inheritance: Rejections', function () {
 
-    it ('should reject programs that use inheritance', function (done) {
-        var code = 'contract Parent {}\ncontract Child is Parent {}';
+    it ('should reject programs that use inheritance and don\'t allow interfaces', function (done) {
+        var code = [
+            'contract Parent {}\ncontract Child is Parent {}',
+            'interface Foo {}\ncontract Bar is Foo {}'
+        ]
         var errors;
 
-        errors = Solium.lint (code, userConfig);
-        errors.length.should.equal (1);
+        for (let expr of code) {
+            errors = Solium.lint (expr, userConfigNoInterface);
+            errors.length.should.equal (1);
+        }
+
+        Solium.reset ();
+        done ();
+    });
+
+    it ('should reject programs that use inheritance without interfaces', function (done) {
+        var code = [
+            'contract Foo {}\ncontract Bar is Foo {}',
+            'contract Foo {}\ncontract Bar {}\ncontract FooBar is Foo,Bar {}'
+        ];
+        var errors;
+
+        for (let expr of code) {
+            errors = Solium.lint (expr, userConfig);
+            errors.length.should.equal (1);
+        }
+
+        Solium.reset ();
+        done ();
+    });
+});
+
+describe ('[RULE] no-inheritance: Handling options', function () {
+
+    it ('should reject rules with invalid user options', function (done) {
+        var code = 'contract Foo {}';
+        var options = [
+            ["error", { "no-interffff": true }],
+            ["error", { 1: 2 }],
+            ["error", { "no-interface": null }],
+            ["error", [true]],
+            ["error", { "no-interface": [true] }],
+            ["error", { "": false }],
+            ["error", { "no-interface": true, "extraRandomProperty": "blah" }]
+        ];
+
+        for (let option of options) {
+            let config = {
+                rules: {
+                    "security/no-inheritance": option
+                }
+            };
+
+            Solium.lint.bind (Solium, code, config).
+                should.throw('Invalid options were passed to rule "security/no-inheritance".');
+        }
 
         Solium.reset ();
         done ();

--- a/test/no-multiple-inheritance.js
+++ b/test/no-multiple-inheritance.js
@@ -13,14 +13,36 @@ var userConfig = {
     }
 };
 
+var userConfigNoInterface = {
+    rules: {
+        "security/no-multiple-inheritance": ["error", { "no-interface": true }]
+    }
+};
+
 describe ('[RULE] no-multiple-inheritance: Acceptances', function () {
 
-    it ('should accept programs that don\'t use multiple inheritance', function (done) {
+    it ('should accept programs that don\'t use multiple inheritance and don\'t allow interfaces', function (done) {
         var code = 'contract Parent {}\ncontract Child is Parent{}';
         var errors;
 
-        errors = Solium.lint (code, userConfig);
+        errors = Solium.lint (code, userConfigNoInterface);
         errors.length.should.equal (0);
+
+        Solium.reset ();
+        done ();
+    });
+
+    it ('should accept programs that use multiple inheritance with interfaces', function (done) {
+        var code = [
+            'interface Foo {}\ninterface Bar {}\ncontract FooBar is Foo,Bar {}',
+            'interface One {}\ninterface Two {}\ninterface Three {}\ncontract Foo is One,Two,Three {}'
+        ];
+        var errors;
+
+        for (let expr of code) {
+            errors = Solium.lint (expr, userConfig);
+            errors.length.should.equal (0);
+        }
 
         Solium.reset ();
         done ();
@@ -29,12 +51,63 @@ describe ('[RULE] no-multiple-inheritance: Acceptances', function () {
 
 describe ('[RULE] no-multiple-inheritance: Rejections', function () {
 
-    it ('should reject programs that use multiple inheritance', function (done) {
-        var code = 'contract Parent {}\ncontract Uncle {}\ncontract Child is Parent,Uncle {}';
+    it ('should reject programs that use multiple inheritance and don\'t allow interfaces', function (done) {
+        var code = [
+            'interface Parent {}\ninterface Uncle {}\ncontract Child is Parent,Uncle {}',
+            'contract Parent {}\ncontract Uncle {}\ncontract Child is Parent,Uncle {}'
+        ];
         var errors;
 
-        errors = Solium.lint (code, userConfig);
-        errors.length.should.equal (1);
+        for (let expr of code) {
+            errors = Solium.lint (expr, userConfigNoInterface);
+            errors.length.should.equal (1);
+        }
+
+        Solium.reset ();
+        done ();
+    });
+
+    it ('should reject programs that use multiple inheritance without interfaces', function (done) {
+        var code = [
+            'contract Foo {}\ncontract Bar {}\ncontract FooBar is Foo,Bar {}',
+            'interface Foo {}\ncontract Bar {}\ncontract FooBar is Foo,Bar {}'
+        ];
+        var errors;
+
+        for (let expr of code) {
+            errors = Solium.lint (expr, userConfig);
+            errors.length.should.equal (1);
+        }
+
+        Solium.reset ();
+        done ();
+    });
+});
+
+describe ('[RULE] no-multiple-inheritance: Handling options', function () {
+
+    it ('should reject rules with invalid user options', function (done) {
+        var code = 'contract Foo {}';
+        var options = [
+            ["error", { "no-interffff": true }],
+            ["error", { 1: 2 }],
+            ["error", { "no-interface": null }],
+            ["error", [true]],
+            ["error", { "no-interface": [true] }],
+            ["error", { "": false }],
+            ["error", { "no-interface": true, "extraRandomProperty": "blah" }]
+        ];
+
+        for (let option of options) {
+            let config = {
+                rules: {
+                    "security/no-multiple-inheritance": option
+                }
+            };
+
+            Solium.lint.bind (Solium, code, config).
+                should.throw('Invalid options were passed to rule "security/no-multiple-inheritance".');
+        }
 
         Solium.reset ();
         done ();


### PR DESCRIPTION
In response to [Augur bounties](https://augur.net/bounties/): "Prohibit use of multiple inheritance but allow interfaces" and "Prohibit use of inheritance but allow interfaces".

Let me know if there's anything to fix.