### PR TITLE
.gitignore now includes .swp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+*.swp


### PR DESCRIPTION
Useful so that using vim doesn't end up with a tonne of .swp files being added as I've done too many times now in this repo