### PR TITLE
Replaced type checks with Solium util functions

### DIFF
--- a/rules/else-after-elseif.js
+++ b/rules/else-after-elseif.js
@@ -18,6 +18,8 @@ module.exports = {
 	},
 
 	create(context) {
+		let source = context.getSourceCode();
+
 		function inspectElseIfStatement(node) {
 			// if the else if does not have an alternate, that means there is
 			// no else - report an error
@@ -26,8 +28,8 @@ module.exports = {
 					node: node,
 					message: "\"else if\" statement must be followed by an \"else\" statement"
 				});
-			} else if (node["alternate"]["type"] === "IfStatement") {
-				inspectElseIfStatement(node["alternate"]); 
+			} else if (source.isIfStatement(node["alternate"])) {
+				inspectElseIfStatement(node["alternate"]);
 			}
 		}
 
@@ -39,17 +41,17 @@ module.exports = {
 			let parent = sourceCode.getParent(node);
 
 			// only inspect top-level if statements
-			if (parent["type"] == "IfStatement") {
+			if (source.isIfStatement(parent)) {
 				return;
 			}
 
-			if (node["alternate"] && node["alternate"]["type"] === "IfStatement") {
+			if (node["alternate"] && source.isIfStatement(node["alternate"])) {
 				inspectElseIfStatement(node["alternate"]);
 			}
 		}
 
 		return {
-			IfStatement: inspectIfStatement 
+			IfStatement: inspectIfStatement
 		};
 	}
 

--- a/rules/enforce-loop-bounds.js
+++ b/rules/enforce-loop-bounds.js
@@ -20,17 +20,18 @@ module.exports = {
 	},
 
 	create: function (context) {
+		let source = context.getSourceCode();
 
 		// eslint-disable-next-line no-unused-vars
 		function hasBreakStatement(expr, index, array) {
-			return expr.type === "BreakStatement";
+			return source.isBreakStatement(expr);
 		}
 
 		function inspectIfStatement(node) {
 			// This returns true if it finds a 'break' statement in the 'if' block
-			if (node.alternate && node.alternate.type === "IfStatement") {
+			if (node.alternate && source.isIfStatement(node.alternate)) {
 				return inspectIfStatement(node.alternate);
-			} else if (node.alternate && node.alternate.type === "BlockStatement") {
+			} else if (node.alternate && source.isBlockStatement(node.alternate)) {
 				if (node.alternate.body.some(hasBreakStatement)) { return true; }
 			}
 
@@ -43,10 +44,10 @@ module.exports = {
 			let hasBreak = false;
 
 			for (let expr of node.body.body) {
-				if (expr.type === "BreakStatement") {
+				if (source.isBreakStatement(expr)) {
 					hasBreak = true;
 					break;
-				} else if (expr.type === "IfStatement") {
+				} else if (source.isIfStatement(expr)) {
 					hasBreak = inspectIfStatement(expr);
 				}
 			}

--- a/rules/no-assign-params.js
+++ b/rules/no-assign-params.js
@@ -18,16 +18,17 @@ module.exports = {
 		schema: []
 	},
 
-	create: function (context) {
+	create(context) {
+		let source = context.getSourceCode();
 
 		function isBadAssignment (statement, params) {
-			return statement["expression"]["type"] === "AssignmentExpression" &&
-                   params.indexOf(statement["expression"]["left"]["name"]) >= 0;
+			return source.isAssignment(statement["expression"]) &&
+						 params.indexOf(statement["expression"]["left"]["name"]) >= 0;
 		}
 
 		function isBadUpdate (statement, params) {
-			return statement["expression"]["type"] === "UpdateExpression" &&
-                   params.indexOf(statement["expression"]["argument"]["name"]) >= 0;
+			return source.isUpdate(statement["expression"]) &&
+						 params.indexOf(statement["expression"]["argument"]["name"]) >= 0;
 
 		}
 
@@ -44,11 +45,11 @@ module.exports = {
 		}
 
 		function inspectStatement (statement, node, params, following) {
-			if ("ExpressionStatement" === following["type"]) {
+			if (source.isExpression(following)) {
 				checkExpressionStatement (following, node, params);
-			} else if ("IfStatement" === following["type"]) {
+			} else if (source.isIfStatement(following)) {
 				inspectIf (following, node, params);
-			} else if (["ForStatement", "WhileStatement", "DoWhileStatement"].indexOf(following["type"]) >= 0) {
+			} else if (source.isLoopStatement(following)) {
 				inspectLoop (following, node, params);
 			} else {
 				inspectBody (following["body"], node, params);
@@ -68,11 +69,11 @@ module.exports = {
 
 		function inspectBody (body, node, params) {
 			for (let statement of body) {
-				if ("ExpressionStatement" === statement["type"]) {
+				if (source.isExpression(statement)) {
 					checkExpressionStatement (statement, node, params);
-				} else if (["ForStatement", "WhileStatement", "DoWhileStatement"].indexOf(statement["type"]) >= 0) {
+				} else if (source.isLoopStatement(statement)) {
 					inspectLoop (statement, node, params);
-				} else if ("IfStatement" === statement["type"]) {
+				} else if (source.isIfStatement(statement)) {
 					inspectIf (statement, node, params);
 				}
 			}

--- a/rules/no-assign-params.js
+++ b/rules/no-assign-params.js
@@ -23,12 +23,12 @@ module.exports = {
 
 		function isBadAssignment (statement, params) {
 			return source.isAssignment(statement["expression"]) &&
-						 params.indexOf(statement["expression"]["left"]["name"]) >= 0;
+			       params.indexOf(statement["expression"]["left"]["name"]) >= 0;
 		}
 
 		function isBadUpdate (statement, params) {
 			return source.isUpdate(statement["expression"]) &&
-						 params.indexOf(statement["expression"]["argument"]["name"]) >= 0;
+			       params.indexOf(statement["expression"]["argument"]["name"]) >= 0;
 
 		}
 

--- a/rules/no-block-members.js
+++ b/rules/no-block-members.js
@@ -27,6 +27,7 @@ module.exports = {
 	},
 
 	create(context) {
+		let source = context.getSourceCode();
 		const membersToAvoid = new Set(context.options ? context.options[0] : MEMBERS_TO_AVOID);
 
 		function reportIfblockhashUsed(emitted) {
@@ -34,7 +35,7 @@ module.exports = {
 
 			const {node} = emitted;
 
-			if (node.callee.type !== "MemberExpression") { return; }
+			if (!source.isMember(node.callee)) { return; }
 
 			const {object, property} = node.callee;
 

--- a/rules/no-call-value.js
+++ b/rules/no-call-value.js
@@ -18,19 +18,21 @@ module.exports = {
 	},
 
 	create(context) {
+		let source = context.getSourceCode();
+
 		function reportIfcallvalueUsed(emitted) {
 			if (emitted.exit) { return; }
 
 			const {node} = emitted, {object, property} = node.callee;
 
-			if (node.callee.type === "MemberExpression" && property.type === "Identifier" && property.name === "value"
-                && object.type === "MemberExpression" && object.property.type === "Identifier"
+			if (source.isMember(node.callee) && property.type === "Identifier" && property.name === "value"
+                && source.isMember(object) && object.property.type === "Identifier"
                 && object.property.name === "call") {
 
 				context.report({
 					node,
 					location: {
-						column: context.getSourceCode().getColumn(object.property)
+						column: source.getColumn(object.property)
 					},
 					message: "Consider using 'transfer' in place of 'call.value()'."
 				});

--- a/rules/no-low-level-calls.js
+++ b/rules/no-low-level-calls.js
@@ -27,12 +27,13 @@ module.exports = {
 	},
 
 	create(context) {
+		let source = context.getSourceCode();
 		const functionsToAvoid = new Set(context.options ? context.options[0] : DEFAULT_FUNCS_TO_AVOID);
 
 		function reportIfUsingFuncToAvoid(emitted) {
 			const {node} = emitted;
 
-			if (emitted.exit || node.callee.type !== "MemberExpression") {
+			if (emitted.exit || !source.isMember(node.callee)) {
 				return;
 			}
 

--- a/rules/no-modify-for-iter-var.js
+++ b/rules/no-modify-for-iter-var.js
@@ -23,8 +23,9 @@ module.exports = {
 
 		function inspectLoopStatement(emitted) {
 			const node = emitted.node;
+			let source = context.getSourceCode();
 
-			if (emitted.exit || !node.init || node.init.type !== "AssignmentExpression") {
+			if (emitted.exit || !node.init || source.isAssignment(node.init)) {
 				return;
 			}
 
@@ -37,9 +38,9 @@ module.exports = {
 
 				let name;
 
-				if (expr.expression.type === "AssignmentExpression" && expr.expression.left.type === "Identifier") {
+				if (source.isAssignment(expr.expression) && expr.expression.left.type === "Identifier") {
 					name = expr.expression.left.name;
-				} else if (expr.expression.type === "UpdateExpression" && expr.expression.argument.type === "Identifier") {
+				} else if (source.isUpdate(expr.expression) && expr.expression.argument.type === "Identifier") {
 					name = expr.expression.argument.name;
 				} else {
 					continue;


### PR DESCRIPTION
There's currently the following issue happening on testing:

`TypeError: source.isAssignment is not a function`

So it seems that `context.getSourceCode()` does not have the functions that were specified in the Solium utils file. Not sure if this is a result of the funky testing stuff happening for this repo or if I've done something wrong. If someone could help point out the issue that'd be greatly appreciated.