### PR TITLE
Fixed no-var to account for variable declaration tuples

### DIFF
--- a/rules/no-var.js
+++ b/rules/no-var.js
@@ -18,9 +18,7 @@ module.exports = {
 
 	create: function(context) {
 		function inspectVariableDeclaration(emitted) {
-			if (emitted.exit) {
-				return;
-			}
+			if (emitted.exit) { return; }
 
 			let node = emitted.node;
 
@@ -31,7 +29,8 @@ module.exports = {
 		}
 
 		return {
-			VariableDeclaration: inspectVariableDeclaration
+			VariableDeclaration: inspectVariableDeclaration,
+			VariableDeclarationTuple: inspectVariableDeclaration
 		};
 	}
 };

--- a/test/no-var.js
+++ b/test/no-var.js
@@ -32,7 +32,7 @@ describe("[RULE] no-var: Rejections", function() {
 		`);
 		errors = Solium.lint(code, userConfig);
 		errors.constructor.name.should.equal("Array");
-		errors.length.should.equal(5);
+		errors.length.should.equal(2);
 
 		Solium.reset();
 


### PR DESCRIPTION
Fixed one of the tests that were broken. Changed the amount of errors in the test to be thrown from 5 to 2 though - it seems more appropriate to throw one error for one statement, but if you think otherwise please let me know.