### PR TITLE
Fixed no-fixed to capture out-of-function declarations

### DIFF
--- a/rules/no-fixed.js
+++ b/rules/no-fixed.js
@@ -17,28 +17,22 @@ module.exports = {
 	},
 
 	create: function(context) {
-		function inspectDeclarationExpression(emitted) {
+		function inspectType(emitted) {
 			if (emitted.exit) {
 				return;
 			}
 
-			let node = emitted.node;
-			let variableType = node.literal.literal;
-
-			if (typeof variableType !== "string") {
-				return;
-			}
-
-			if (variableType.indexOf("fixed") === 0 || variableType.indexOf("ufixed") === 0) {
+			let type = emitted.node.literal;
+			if (type.indexOf("fixed") === 0 || type.indexOf("ufixed") === 0) {
 				context.report({
-					node: node,
-					message: `${variableType}: Avoid using fixed types.`
+					node: emitted.node,
+					message: `${type}: Avoid using fixed types.`
 				});
 			}
 		}
 
 		return {
-			DeclarativeExpression: inspectDeclarationExpression
+			Type: inspectType
 		};
 	}
 };

--- a/test/no-fixed.js
+++ b/test/no-fixed.js
@@ -39,6 +39,8 @@ describe("[RULE] no-fixed: Rejections", function() {
 		let code = toContract(`
 			fixed x = 100.89;
 			ufixed y = 1.2;
+			uint z = 3;
+			uint[] a;
 
 			function foo () {
 				fixed a = 2.0; ufixed b = 90.2;


### PR DESCRIPTION
The errors were coming up because declarations outside of functions were not being caught. Fixed the code so that they are caught.